### PR TITLE
ci(github): migrate CI from Gitlab to github

### DIFF
--- a/.github/workflows/bump.yaml
+++ b/.github/workflows/bump.yaml
@@ -1,0 +1,31 @@
+---
+
+name: 'Bump'
+
+
+on:
+  workflow_dispatch:
+    inputs:
+      CZ_PRE_RELEASE:
+        default: none
+        required: false
+        description: Create Pre-Release {alpha,beta,rc,none}
+      CZ_INCREMENT:
+        default: none
+        required: false
+        description: Type of bump to conduct {MAJOR,MINOR,PATCH,none}
+  push:
+    branches:
+      - 'master'
+
+
+jobs:
+
+  bump:
+    name: 'Bump'
+    uses: nofusscomputing/action_bump/.github/workflows/bump.yaml@development
+    with:
+      CZ_PRE_RELEASE: ${{ inputs.CZ_PRE_RELEASE }}
+      CZ_INCREMENT: ${{ inputs.CZ_INCREMENT }}
+    secrets:
+      WORKFLOW_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,12 @@ jobs:
   collection:
     name: 'Ansible Collection'
     uses: nofusscomputing/action_ansible_collection/.github/workflows/reusable_ansible_collection.yaml@development
+    permissions:
+      pull-requests: write
+      contents: write
+      statuses: write
+      checks: write
+      actions: write
     with:
       ANSIBLE_COLLECTION_MARK_RELEASE_LIVE: true
       ANSIBLE_GALAXY_NAMESPACE: "${{ github.repository_owner }}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,18 @@ env:
 jobs:
 
 
+  collection:
+    name: 'Ansible Collection'
+    uses: nofusscomputing/action_ansible_collection/.github/workflows/reusable_ansible_collection.yaml@development
+    with:
+      ANSIBLE_COLLECTION_MARK_RELEASE_LIVE: true
+      ANSIBLE_GALAXY_NAMESPACE: "${{ github.repository_owner }}"
+      ANSIBLE_GALAXY_PACKAGE_NAME: "${{ github.event.repository.name }}"
+      ANSIBLE_LINTING_MUST_PASS: true
+    secrets:
+      ANSIBLE_GALAXY_UPLOAD_TOKEN: ${{ secrets.ANSIBLE_GALAXY_UPLOAD_TOKEN }}
+
+
   gitlab-mirror:
     if: ${{ github.repository == 'nofusscomputing/ansible_collection_centurion' }}
     runs-on: ubuntu-latest

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+    "recommendations": [
+        "redhat.ansible",
+        "streetsidesoftware.code-spell-checker-australian-english",
+        "streetsidesoftware.code-spell-checker",
+        "github.vscode-github-actions",
+        "jebbs.markdown-extended"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <br>
 
-![Project Status - Active](https://img.shields.io/badge/Project%20Status-Active-green?logo=gitlab&style=plastic) 
+![Project Status - Active](https://img.shields.io/badge/Project%20Status-Active-green?logo=github&style=plastic) 
 
 
 [![Downloads](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fgalaxy.ansible.com%2Fapi%2Fv3%2Fplugin%2Fansible%2Fcontent%2Fpublished%2Fcollections%2Findex%2Fnofusscomputing%2Fcenturion%2F&query=%24.download_count&style=plastic&logo=ansible&logoColor=white&label=Galaxy%20Downloads&labelColor=black&color=cyan)](https://galaxy.ansible.com/ui/repo/published/nofusscomputing/centurion/)
@@ -14,28 +14,28 @@
 
 <br>
 
-![Gitlab forks count](https://img.shields.io/badge/dynamic/json?label=Forks&query=%24.forks_count&url=https%3A%2F%2Fgitlab.com%2Fapi%2Fv4%2Fprojects%2F59504579%2F&color=ff782e&logo=gitlab&style=plastic) ![Gitlab stars](https://img.shields.io/badge/dynamic/json?label=Stars&query=%24.star_count&url=https%3A%2F%2Fgitlab.com%2Fapi%2Fv4%2Fprojects%2F59504579%2F&color=ff782e&logo=gitlab&style=plastic) [![Open Issues](https://img.shields.io/badge/dynamic/json?color=ff782e&logo=gitlab&style=plastic&label=Open%20Issues&query=%24.statistics.counts.opened&url=https%3A%2F%2Fgitlab.com%2Fapi%2Fv4%2Fprojects%2F59504579%2Fissues_statistics)](https://gitlab.com/nofusscomputing/projects/ansible/collections/kubernetes/-/issues)
+![GitHub forks](https://img.shields.io/github/forks/NofussComputing/ansible_collection_centurion?logo=github&style=plastic&color=000000&labell=Forks) ![GitHub stars](https://img.shields.io/github/stars/NofussComputing/ansible_collection_centurion?color=000000&logo=github&style=plastic) ![Github Watchers](https://img.shields.io/github/watchers/NofussComputing/ansible_collection_centurion?color=000000&label=Watchers&logo=github&style=plastic) 
+
+![Gitlab forks count](https://img.shields.io/badge/dynamic/json?label=Forks&query=%24.forks_count&url=https%3A%2F%2Fgitlab.com%2Fapi%2Fv4%2Fprojects%2F59504579%2F&color=ff782e&logo=gitlab&style=plastic) ![Gitlab stars](https://img.shields.io/badge/dynamic/json?label=Stars&query=%24.star_count&url=https%3A%2F%2Fgitlab.com%2Fapi%2Fv4%2Fprojects%2F59504579%2F&color=ff782e&logo=gitlab&style=plastic)
 
 
-
-![GitHub forks](https://img.shields.io/github/forks/NofussComputing/ansible_collection_centurion?logo=github&style=plastic&color=000000&labell=Forks) ![GitHub stars](https://img.shields.io/github/stars/NofussComputing/ansible_collection_centurion?color=000000&logo=github&style=plastic) ![Github Watchers](https://img.shields.io/github/watchers/NofussComputing/ansible_collection_centurion?color=000000&label=Watchers&logo=github&style=plastic)
 <br>
 
-This project is hosted on [gitlab](https://gitlab.com/nofusscomputing/projects/ansible/collections/kubernetes) and has a read-only copy hosted on [Github](https://github.com/NofussComputing/ansible_collection_centurion).
+This project is hosted on [Github](https://github.com/NofussComputing/ansible_collection_centurion) and has a read-only copy hosted on [gitlab](https://gitlab.com/nofusscomputing/projects/ansible/collections/kubernetes).
 
 ----
 
 **Stable Branch**
 
-![Gitlab build status - stable](https://img.shields.io/badge/dynamic/json?color=ff782e&label=Build&query=0.status&url=https%3A%2F%2Fgitlab.com%2Fapi%2Fv4%2Fprojects%2F59504579%2Fpipelines%3Fref%3Dmaster&logo=gitlab&style=plastic) ![branch release version](https://img.shields.io/badge/dynamic/yaml?color=ff782e&logo=gitlab&style=plastic&label=Release&query=%24.commitizen.version&url=https%3A//gitlab.com/nofusscomputing/projects/ansible/collections/centurion_erp_collection%2F-%2Fraw%2Fmaster%2F.cz.yaml) 
-
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/nofusscomputing/ansible_collection_centurion/ci.yaml?branch=master&style=plastic&logo=github&label=Build&color=%23000) ![GitHub Release](https://img.shields.io/github/v/release/nofusscomputing/ansible_collection_centurion?sort=date&style=plastic&logo=github&label=Release&color=000)
 
 
 ----
 
 **Development Branch** 
 
-![Gitlab build status - development](https://img.shields.io/badge/dynamic/json?color=ff782e&label=Build&query=0.status&url=https%3A%2F%2Fgitlab.com%2Fapi%2Fv4%2Fprojects%2F59504579%2Fpipelines%3Fref%3Ddevelopment&logo=gitlab&style=plastic) ![branch release version](https://img.shields.io/badge/dynamic/yaml?color=ff782e&logo=gitlab&style=plastic&label=Release&query=%24.commitizen.version&url=https%3A//gitlab.com/nofusscomputing/projects/ansible/collections/centurion_erp_collection%2F-%2Fraw%2Fdevelopment%2F.cz.yaml)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/nofusscomputing/ansible_collection_centurion/ci.yaml?branch=development&style=plastic&logo=github&label=Build&color=%23000) ![GitHub Release](https://img.shields.io/github/v/release/nofusscomputing/ansible_collection_centurion?include_prereleases&sort=date&style=plastic&logo=github&label=Release&color=000)
+
 
 ----
 <br>
@@ -52,7 +52,7 @@ This Ansible collection is a companion collection for [Centurion ERP](https://no
 
 
 ## Contributing
-All contributions for this project must conducted from [Gitlab](https://gitlab.com/nofusscomputing/projects/ansible/collections/centurion_erp_collection).
+All contributions for this project must conducted from [Github](https://github.com/NofussComputing/ansible_collection_centurion).
 
 For further details on contributing please refer to the [contribution guide](CONTRIBUTING.md).
 

--- a/docs/projects/ansible/collection/centurion/index.md
+++ b/docs/projects/ansible/collection/centurion/index.md
@@ -8,14 +8,12 @@ about: https://gitlab.com/nofusscomputing/projects/ansible/collections/kubernete
 
 <span style="text-align: center;">
 
-![Project Status - Active](https://img.shields.io/badge/Project%20Status-Active-green?logo=gitlab&style=plastic) 
+![Project Status - Active](https://img.shields.io/badge/Project%20Status-Active-green?logo=github&style=plastic) 
 
 
-![Gitlab build status - stable](https://img.shields.io/badge/dynamic/json?color=ff782e&label=Build&query=0.status&url=https%3A%2F%2Fgitlab.com%2Fapi%2Fv4%2Fprojects%2F59504579%2Fpipelines%3Fref%3Dmaster&logo=gitlab&style=plastic) ![Gitlab build status - development](https://img.shields.io/badge/dynamic/json?color=ff782e&label=Build&query=0.status&url=https%3A%2F%2Fgitlab.com%2Fapi%2Fv4%2Fprojects%2F59504579%2Fpipelines%3Fref%3Ddevelopment&logo=gitlab&style=plastic)
+![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/nofusscomputing/ansible_collection_centurion/ci.yaml?branch=master&style=plastic&logo=github&label=Build&color=%23000) ![GitHub Release](https://img.shields.io/github/v/release/nofusscomputing/ansible_collection_centurion?sort=date&style=plastic&logo=github&label=Release&color=000) 
 
-
-
-![branch release version](https://img.shields.io/badge/dynamic/yaml?color=ff782e&logo=gitlab&style=plastic&label=Release&query=%24.commitizen.version&url=https%3A//gitlab.com/nofusscomputing/projects/ansible/collections/centurion_erp_collection%2F-%2Fraw%2Fmaster%2F.cz.yaml) [![Downloads](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fgalaxy.ansible.com%2Fapi%2Fv3%2Fplugin%2Fansible%2Fcontent%2Fpublished%2Fcollections%2Findex%2Fnofusscomputing%2Fcenturion%2F&query=%24.download_count&style=plastic&logo=ansible&logoColor=white&label=Galaxy%20Downloads&labelColor=black&color=cyan)](https://galaxy.ansible.com/ui/repo/published/nofusscomputing/centurion/)
+[![Downloads](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fgalaxy.ansible.com%2Fapi%2Fv3%2Fplugin%2Fansible%2Fcontent%2Fpublished%2Fcollections%2Findex%2Fnofusscomputing%2Fcenturion%2F&query=%24.download_count&style=plastic&logo=ansible&logoColor=white&label=Galaxy%20Downloads&labelColor=black&color=cyan)](https://galaxy.ansible.com/ui/repo/published/nofusscomputing/centurion/)
 
 
 

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,7 +1,7 @@
 ---
 # Collections must specify a minimum required ansible version to upload
 # to galaxy
-requires_ansible: '>=2.9.10'
+requires_ansible: '>=2.16.0'
 
 # Content that Ansible needs to load from another location or that has
 # been deprecated/removed


### PR DESCRIPTION
setup github CI so that all except docs is done on github. Docs will remain on gitlab.


## Links


- Blocks #17 


- Blocked By: https://github.com/nofusscomputing/action_ansible_collection/pull/1


- Related: #15